### PR TITLE
feat: Implement onTermination() for process exit signal handling

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,5 +18,6 @@ overrides:
     env:
       mocha: true
     rules:
+      'jsdoc/require-jsdoc': off
       no-unused-expressions: off
       '@typescript-eslint/no-unused-expressions': off

--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,2 @@
 export * from './lib/express-promises.js'
+export * from './lib/termination.js'

--- a/lib/termination.ts
+++ b/lib/termination.ts
@@ -1,0 +1,48 @@
+import { constants } from 'os'
+
+export type TerminationCallback = (signal: NodeJS.Signals) => (void | Promise<void>)
+
+class Terminator {
+  private exiting = false
+  private readonly callbacks: TerminationCallback[] = []
+
+  async handleSignal (signal: NodeJS.Signals): Promise<void> {
+    if (this.exiting) {
+      return
+    }
+    this.exiting = true
+    // Invoke in reverse order in case any callbacks registered later depend on things registered earlier
+    for (let i = this.callbacks.length - 1; i >= 0; --i) {
+      await this.callbacks[i](signal)
+    }
+    // POSIX process exit code is typically 128+signal, such as 143 for SIGTERM
+    process.exit(128 + constants.signals[signal])
+  }
+
+  registerCallback (callback: TerminationCallback): void {
+    this.callbacks.push(callback)
+  }
+}
+
+const handler = new Terminator()
+
+for (const signal of ['SIGTERM', 'SIGINT'] as const) {
+  process.once(signal, () => {
+    void handler.handleSignal(signal)
+  })
+}
+
+/**
+ * Register a callback for when termination of the process is requested via an external signal. When a signal is
+ * received, all callbacks will be run serially in reverse order, and then the process will exit.
+ * Explicit termination such as via process.exit() will not invoke any of the callbacks.
+ *
+ * The callback can be asynchronous, returning a Promise. Still it is required to limit the total amount of time spent
+ * in termination callbacks, since the OS (or container orchestration) might forcefully kill the process a few seconds
+ * after the signal.
+ *
+ * @param fn The callback to register.
+ */
+export function onTermination (fn: TerminationCallback): void {
+  handler.registerCallback(fn)
+}

--- a/test/termination-fixture.ts
+++ b/test/termination-fixture.ts
@@ -1,0 +1,19 @@
+import { onTermination } from '../lib/termination.js'
+
+/*
+ * This file is started as its own process by termination.test.ts
+ */
+
+onTermination((signal) => console.log(`t0: ${signal}`))
+onTermination(async (signal) => {
+  await new Promise(resolve => setTimeout(resolve, 100))
+  console.log(`t1: ${signal}`)
+})
+onTermination((signal) => console.log(`t2: ${signal}`))
+
+// Keep the process running for a few seconds so the signal can be sent
+setTimeout(() => {
+  console.log('timeout!')
+}, 5000)
+
+console.log('started')

--- a/test/termination.test.ts
+++ b/test/termination.test.ts
@@ -1,0 +1,112 @@
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+import { ChildProcess, fork } from 'child_process'
+import { setTimeout as delay } from 'timers/promises'
+import * as url from 'url'
+
+chai.use(chaiAsPromised)
+
+async function waitUntil (condition: () => boolean, timeout: number): Promise<void> {
+  const start = Date.now()
+  while (!condition()) {
+    if (Date.now() - start > timeout) {
+      throw new Error('timeout')
+    }
+    await delay(100)
+  }
+}
+
+describe('/lib/termination', function () {
+  const FIXTURE_PATH = url.fileURLToPath(new URL('termination-fixture.ts', import.meta.url))
+
+  async function performSignalTest (signal: NodeJS.Signals): Promise<{ fixture: ChildProcess, outLines: string[] }> {
+    // necessary precondition for running the fixture (should be true since tests are also running via ts-node)
+    expect(process.execArgv).to.deep.equal(['--loader=ts-node/esm'])
+
+    // { silent: true } makes available stdout and stderr
+    const fixture = fork(FIXTURE_PATH, { silent: true })
+
+    expect(fixture.stdout).to.be.an('object')
+    expect(fixture.stderr).to.be.an('object')
+
+    const outLines: string[] = []
+    const errLines: string[] = []
+    fixture.stdout?.on('data', (chunk) => outLines.push(chunk.toString().trim()))
+    fixture.stderr?.on('data', (chunk) => {
+      const errLine = chunk.toString().trim()
+      // These warnings are emitted due to ts-node
+      if (!/--experimental-loader|--trace-warnings/.test(errLine)) {
+        errLines.push(errLine)
+      }
+    })
+
+    await waitUntil(() => (outLines.length + errLines.length) > 0, 6000)
+    expect(fixture.kill(signal)).to.equal(true)
+    await waitUntil(() => fixture.exitCode != null || fixture.signalCode != null, 4000)
+
+    expect(errLines).to.deep.equal([])
+
+    return { fixture, outLines }
+  }
+
+  it('runs callbacks on SIGTERM', async function () {
+    // Windows has no signal support
+    if (process.platform === 'win32') {
+      this.skip()
+      return
+    }
+
+    this.slow(3000)
+    this.timeout(10000)
+
+    const { fixture, outLines } = await performSignalTest('SIGTERM')
+
+    expect(fixture.exitCode).to.equal(143)
+    expect(outLines).to.deep.equal([
+      'started',
+      't2: SIGTERM',
+      't1: SIGTERM',
+      't0: SIGTERM'
+    ])
+  })
+
+  it('runs callbacks on SIGINT', async function () {
+    // Windows has no signal support
+    if (process.platform === 'win32') {
+      this.skip()
+      return
+    }
+
+    this.slow(3000)
+    this.timeout(10000)
+
+    const { fixture, outLines } = await performSignalTest('SIGINT')
+
+    expect(fixture.exitCode).to.equal(130)
+    expect(outLines).to.deep.equal([
+      'started',
+      't2: SIGINT',
+      't1: SIGINT',
+      't0: SIGINT'
+    ])
+  })
+
+  it('does not run callbacks on SIGKILL', async function () {
+    // Windows has no signal support
+    if (process.platform === 'win32') {
+      this.skip()
+      return
+    }
+
+    this.slow(3000)
+    this.timeout(10000)
+
+    const { fixture, outLines } = await performSignalTest('SIGKILL')
+
+    expect(fixture.exitCode).to.equal(null)
+    expect(fixture.signalCode).to.equal('SIGKILL')
+    expect(outLines).to.deep.equal([
+      'started'
+    ])
+  })
+})


### PR DESCRIPTION
The new function onTermination() can be used to register callbacks for
when the process receives a SIGTERM or SIGINT signal. These callbacks
will be run in reverse (compared to the order in which they were added).
After processing all callbacks, the process will exit explicitly.
Callbacks can be async by returning a Promise.

Tests are added for this behavior on POSIX systems. These same tests
cannot be replicated on Windows due to lack of signal support. Still,
Node.js will emulate SIGINT when CTRL+C is pressed in a Windows shell,
meaning the effectiveness of this code on Windows is still pretty much
guaranteed, we simply cannot run the tests.