### PR TITLE
feat: Implement promisifiedListen(), promisifiedClose() generically

### DIFF
--- a/src/express-promises.ts
+++ b/src/express-promises.ts
@@ -1,16 +1,28 @@
-import { Application } from 'express'
-import { Server } from 'http'
+import EventEmitter from 'events'
+
+interface Listenable<ServerType extends EventEmitter> {
+  listen: ((port: number, hostname: string, callback?: () => void) => ServerType) &
+  ((port: number, callback?: () => void) => ServerType) &
+  ((callback?: () => void) => ServerType)
+}
+
+interface Closable extends EventEmitter {
+  close: (cb: (err?: Error) => void) => any
+}
 
 /**
- * Start an Express application on the given port, returning a Promise.
- * The Promise is resolved only as soon as the server is listening.
+ * Invoke the object's callback-based listen() method, returning a Promise to the created server.
+ * The Promise is resolved only as soon as the server is listening, as indicated by its 'listening' event.
+ *
+ * This function can be used to start Express applications, but also regular http.Server instances etc.,
+ * as long as they have a compatible listen() method.
  *
  * @param app The application to start.
  * @param port The port to listen on.
  * @param hostname The hostname to listen on.
- * @returns A Promise that resolves to the started HTTP server.
+ * @returns A Promise that resolves to the started server.
  */
-export async function promisifiedListen (app: Application, port: number, hostname?: string): Promise<Server> {
+export async function promisifiedListen<ServerType extends EventEmitter> (app: Listenable<ServerType>, port: number, hostname?: string): Promise<ServerType> {
   return await new Promise((resolve, reject) => {
     const httpServer = hostname != null ? app.listen(port, hostname) : app.listen(port)
     httpServer.once('listening', () => resolve(httpServer))
@@ -19,13 +31,14 @@ export async function promisifiedListen (app: Application, port: number, hostnam
 }
 
 /**
- * Stop listening for requests.
- * The returned Promise is resolved only as soon as the port is free again.
+ * Invoke the object's callback-based close() method, returning a Promise.
+ *
+ * This is intended to stop http.Server instances but can be used for anything with a compatible close() method.
  *
  * @param server The server to close.
  * @returns A Promise that resolves when done.
  */
-export async function promisifiedClose (server: Server): Promise<void> {
+export async function promisifiedClose (server: Closable): Promise<void> {
   await new Promise<void>((resolve, reject) => server.close((err) => {
     if (err != null) {
       reject(err)

--- a/test/express-promises.test.ts
+++ b/test/express-promises.test.ts
@@ -20,13 +20,21 @@ describe('express-promises.ts', function () {
     it('resolves with a started server', async function () {
       const server = await promisifiedListen(express(), 3333)
       serversToCleanUp.push(server)
-      // if the server was not started yet, the address() would be null
+      expect(server.listening).to.equal(true)
       expect(server.address()).to.have.property('port').that.equals(3333)
     })
 
     it('rejects if trying to start on a used port', async function () {
       serversToCleanUp.push(await promisifiedListen(express(), 3333))
       await expect(promisifiedListen(express(), 3333)).to.eventually.be.rejectedWith('EADDRINUSE')
+    })
+
+    it('works for plain http.Server', async function () {
+      // The function was initially implemented for express.Application only, but expanded to be more generic.
+      const server = await promisifiedListen(http.createServer(), 3333)
+      serversToCleanUp.push(server)
+      expect(server.listening).to.equal(true)
+      expect(server.address()).to.have.property('port').that.equals(3333)
     })
   })
 
@@ -36,12 +44,20 @@ describe('express-promises.ts', function () {
       serversToCleanUp.push(server)
       expect(server.address()).to.have.property('port').that.equals(3333)
       await expect(promisifiedClose(server)).to.eventually.be.fulfilled
+      expect(server.listening).to.equal(false)
       expect(server.address()).to.equal(null)
     })
 
     it('rejects if the server was not running', async function () {
       const server = http.createServer()
       expect(server.address()).to.equal(null)
+      await expect(promisifiedClose(server)).to.eventually.be.rejectedWith('not running')
+    })
+
+    it('rejects if called twice on the same instance', async function () {
+      const server = http.createServer().listen(3333)
+      serversToCleanUp.push(server)
+      await expect(promisifiedClose(server)).to.eventually.be.fulfilled
       await expect(promisifiedClose(server)).to.eventually.be.rejectedWith('not running')
     })
   })


### PR DESCRIPTION
This patch removes the hard dependency on Express and http.Server for
promisifiedListen() and promisifiedClose(). These methods are useful in
other contexts, too. By requiring only a small interface, we can make
them available generically.