### PR TITLE
test: Avoid output tests failing due to ExperimentalWarning

### DIFF
--- a/test/termination.test.ts
+++ b/test/termination.test.ts
@@ -20,8 +20,8 @@ describe('termination.ts', function () {
     const fixture = fork(FIXTURE_PATH, {
       // Make available stdout and stderr
       silent: true,
-      // Run with ts-node loader
-      execArgv: ['--loader=ts-node/esm']
+      // Run with ts-node loader but prevent it from causing an ExperimentalWarning, which would invalidate the tests
+      execArgv: ['--loader=ts-node/esm', '--no-warnings']
     })
 
     assert.ok(fixture.stdout, 'expected child process to have stdout')
@@ -35,7 +35,7 @@ describe('termination.ts', function () {
     })
     fixture.stderr?.on('data', (chunk: Buffer) => {
       // Filter out warnings emitted due to presence of ts-node loader
-      const lines = chunk.toString().split('\n').filter(line => line.length > 0 && !/ExperimentalWarning|--experimental-loader|--trace-warnings/.test(line))
+      const lines = chunk.toString().split('\n').filter(line => line.length > 0)
       errLines.push(...lines)
     })
 


### PR DESCRIPTION
There was already logic in place to prevent ExperimentalWarning output from affecting the test, but the text was recently changed on Node 20, which made it fail again. Add `--no-warnings` to make the test more resilient.